### PR TITLE
Aws config

### DIFF
--- a/userdata.yml
+++ b/userdata.yml
@@ -1,0 +1,6 @@
+#cloud-config
+write_files:
+- path: /etc/sudoers.d/999-requiretty
+  permissions: 440
+  content: |
+    Defaults:centos !requiretty

--- a/workshop.json
+++ b/workshop.json
@@ -48,9 +48,10 @@
       "type":          "amazon-ebs",
       "source_ami":    "ami-bd523087",
       "region":        "ap-southeast-2",
-      "instance_type": "t2.micro",
+      "instance_type": "m3.medium",
       "ssh_username":  "centos",
-      "ami_name":      "workshop {{timestamp}}"
+      "ami_name":      "workshop {{timestamp}}",
+      "user_data_file": "userdata.yml"
   }
 
 

--- a/workshop.json
+++ b/workshop.json
@@ -24,7 +24,7 @@
 
       "boot_wait": "12s",
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-7.0-dvd-workshop_ks.cfg<enter><wait>"
+        "<tab> rd.live.check=0 text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-7.0-dvd-workshop_ks.cfg<enter><wait>"
       ],
 
       "ssh_username":     "root",


### PR DESCRIPTION
The current configuration requires a VPC to work and won't automatically create one.

this changes to use a larger vm but can build without a vpc.

additionally deploys a sudoer rule to disable requiretty so that packer can configure it
