### PR TITLE
Added missing Ebs.VolumeSize to BlockDeviceMapping

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,6 +77,7 @@ MEDIAREPO
       aws.block_device_mapping = [ {
         :DeviceName               => "/dev/sda1",
         :VirtualName              => "ebs",
+        'Ebs.VolumeSize'          => 1,
         'Ebs.DeleteOnTermination' => true
         } ]
     end


### PR DESCRIPTION
I was getting an `InvalidBlockDeviceMapping => Either snapshot ID or volume size must be provided for: /dev/sda1` error.
